### PR TITLE
Add better player animation

### DIFF
--- a/src/cutthetree/Game.java
+++ b/src/cutthetree/Game.java
@@ -67,6 +67,11 @@ public class Game extends JComponent {
         setFocusable(true);
         addKeyListener(new KeyAdapter() {
             @Override
+            public void keyReleased(KeyEvent e) {
+                if (state == GameState.PLAYING) playField.dispatchEvent(e);
+            }
+
+            @Override
             public void keyPressed(KeyEvent e) {
                 if (state == GameState.START || state == GameState.LEVEL_SELECT) {
                     playScreenKeyHandler(e);
@@ -227,7 +232,7 @@ public class Game extends JComponent {
     }
 
     private void gameLoop() {
-        int fps = 1000 / 12;
+        int fps = 1000 / 30;
 
         while (true) {
             try {

--- a/src/cutthetree/PlayField.java
+++ b/src/cutthetree/PlayField.java
@@ -24,6 +24,7 @@ public class PlayField extends JComponent {
     private int height, width;
     private Player player;
 
+    private boolean walking = false;
     private ArrayList<ArrayList<Field>> fields = new ArrayList<>();
 
     public PlayField(int height, int width, LevelType type, int levelNumber) {
@@ -38,22 +39,31 @@ public class PlayField extends JComponent {
         setFocusable(true);
         addKeyListener(new KeyAdapter() {
             @Override
+            public void keyReleased(KeyEvent e) {
+                walking = false;
+            }
+
+            @Override
             public void keyPressed(KeyEvent e) {
                 player.say("");
 
                 if (!finished) {
                     switch (e.getKeyCode()) {
                         case KeyEvent.VK_UP:
-                            walk(Direction.UP);
+                            player.changeDirection(Direction.UP);
+                            walking = true;
                             break;
                         case KeyEvent.VK_DOWN:
-                            walk(Direction.DOWN);
+                            player.changeDirection(Direction.DOWN);
+                            walking = true;
                             break;
                         case KeyEvent.VK_LEFT:
-                            walk(Direction.LEFT);
+                            player.changeDirection(Direction.LEFT);
+                            walking = true;
                             break;
                         case KeyEvent.VK_RIGHT:
-                            walk(Direction.RIGHT);
+                            player.changeDirection(Direction.RIGHT);
+                            walking = true;
                             break;
                         case KeyEvent.VK_SPACE:
                             cut();
@@ -134,6 +144,8 @@ public class PlayField extends JComponent {
 
     @Override
     protected void paintComponent(Graphics g) {
+        if (walking) walk(player.getDirection());
+
         ((Graphics2D) g).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
         for (ArrayList<Field> row : fields) {

--- a/src/cutthetree/Player.java
+++ b/src/cutthetree/Player.java
@@ -12,7 +12,7 @@ public class Player extends Field {
 
     private int animX;
     private int animY;
-    private int animState = 2;
+    private int animState = 8;
 
     private Lumberaxe axe;
     private String message = "";

--- a/src/cutthetree/Player.java
+++ b/src/cutthetree/Player.java
@@ -80,17 +80,17 @@ public class Player extends Field {
 
         // Calculate current animation positions
         if (animX + animY != 0) {
-            if (animState == 2) {
+            if (animState == 8) {
                 animState = 0;
             } else {
                 animState++;
             }
 
-            x += animX * ((SIZE / 3) * (animState + 1)) + (SIZE * -animX);
-            y += animY * ((SIZE / 3) * (animState + 1)) + (SIZE * -animY);
+            x += animX * ((SIZE / 9) * (animState + 1)) + (SIZE * -animX);
+            y += animY * ((SIZE / 9) * (animState + 1)) + (SIZE * -animY);
 
-            offsetX = animState * SIZE;
-            if (animState == 2) {
+            offsetX = (animState / 4) * SIZE;
+            if (animState == 8) {
                 animX = 0;
                 animY = 0;
             }

--- a/src/cutthetree/Tree.java
+++ b/src/cutthetree/Tree.java
@@ -68,7 +68,7 @@ public class Tree extends Field {
     @Override
     public void paint(Graphics g) {
         super.paint(g);
-        if (animState >= 4) return;
+        if (animState >= 16) return;
 
         int x = xPos * SIZE;
         int y = yPos * SIZE;
@@ -76,11 +76,11 @@ public class Tree extends Field {
 
         // Calculate current animation image offset
         if (animState >= 0) {
-            offset = animState * SIZE;
+            offset = (animState / 4) * SIZE;
 
             animState++;
 
-            if (animState == 4) {
+            if (animState == 16) {
                 isSolid = false;
             }
         }

--- a/test/cutthetree/PlayerTest.java
+++ b/test/cutthetree/PlayerTest.java
@@ -2,7 +2,6 @@ package cutthetree;
 
 import org.junit.Before;
 import org.junit.Test;
-import sun.print.DialogOwner;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;

--- a/test/cutthetree/TreeTest.java
+++ b/test/cutthetree/TreeTest.java
@@ -76,8 +76,12 @@ public class TreeTest {
         // Start cut animation
         testTree1.cut(goodAxe);
 
-        // Animation takes 4 frames
-        for (int i = 0; i < 4; i++) testTree1.paint(g);
+        // Animation takes 16 frames
+        for (int i = 0; i < 16; i++) {
+            assertTrue(testTree1.isSolid());
+
+            testTree1.paint(g);
+        }
 
         // Tree is no longer solid after animation so the player can walk through it
         assertFalse(testTree1.isSolid());


### PR DESCRIPTION
Change FPS from 12 to 30 and change animation for player and tree accordingly

Make the player move in smaller steps every frame for a more fluent animation.
Let the player keep walking while the key stays pressed.

**Player animation now takes 9 frames (was 3) =~ 300ms (was 250ms)
Tree animation now takes 16 frames (was 4) =~ 533ms (was 333ms)**

Before:
![old](https://cloud.githubusercontent.com/assets/1942599/24296815/e6cc9ff4-10a0-11e7-9259-e9479f4a10dc.gif)

After:
![new](https://cloud.githubusercontent.com/assets/1942599/24296824/e897a4e6-10a0-11e7-8f28-c0ff396459cd.gif)