### PR TITLE
Change the way menus are implemented

### DIFF
--- a/src/cutthetree/Game.java
+++ b/src/cutthetree/Game.java
@@ -1,17 +1,19 @@
 package cutthetree;
 
-import javax.imageio.ImageIO;
+import cutthetree.menus.*;
+import cutthetree.menus.Menu;
+
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.Clip;
 import javax.swing.*;
-import java.awt.Color;
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The Game class is responsible for keeping track of
@@ -21,22 +23,10 @@ import java.util.Arrays;
  * disable them when needed.
  */
 public class Game extends JComponent {
-    private Image imageBackground;
-    private Font font;
     private PlayField playField;
 
-    private int selected = 0;
     private int difficulty = 0;
     private static Clip clip;
-    private Image imageField;
-    private Image imageTitle;
-    private Image imagePaused;
-    private Image imageSound;
-    private Image imageNoSound;
-    private Image imageFx;
-    private Image imageNoFx;
-    private int finishSelected = 0;
-
     private static int currentLevel;
 
     private static boolean sound = true, fx = true;
@@ -49,19 +39,8 @@ public class Game extends JComponent {
     private static String[] effects = new String[]{
             "chopping", "grab"
     };
-    private String[] choices = new String[]{
-            "Start", "Difficulty", "Exit"
-    };
-    private String[] choicesMenu = new String[]{
-            "Continue", "Restart", "Exit"};
 
-    private String[] levels = new String[]{
-            "Tutorial", "Easy", "Medium", "Hard", "Back"
-    };
-
-    private String[] finishMenu = new String[]{
-            "Exit"
-    };
+    private Map<GameState, Menu> menus = new HashMap<>();
 
     public Game() {
         setFocusable(true);
@@ -73,80 +52,10 @@ public class Game extends JComponent {
 
             @Override
             public void keyPressed(KeyEvent e) {
-                if (state == GameState.START || state == GameState.LEVEL_SELECT) {
-                    playScreenKeyHandler(e);
-                } else if (state == GameState.FINISHED) {
-                    if (e.getKeyCode() == KeyEvent.VK_ENTER) {
-                        state = GameState.START;
-                    }
+                if (state == GameState.PLAYING) {
+                    playField.dispatchEvent(e);
                 } else {
-                    if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
-                        if (state == GameState.PAUSED) {
-                            state = GameState.PLAYING;
-                        } else {
-                            state = GameState.PAUSED;
-                        }
-                    } else if (state == GameState.PAUSED) {
-                        pausedKeyHandler(e);
-                    } else {
-                        playField.dispatchEvent(e);
-                    }
-                }
-            }
-
-            private void playScreenKeyHandler(KeyEvent e) {
-                switch (e.getKeyCode()) {
-                    case KeyEvent.VK_ENTER:
-                        if (state == GameState.START) {
-                            if (selected == 0) {
-                                playField = new PlayField(12, 12, LevelType.values()[difficulty], 0);
-                                state = GameState.PLAYING;
-                                clip.stop();
-                            } else if (selected == 1) {
-                                state = GameState.LEVEL_SELECT;
-                            } else if (selected == 2) {
-                                System.exit(0);
-                            }
-                        } else {
-                            if (selected < levels.length - 1) difficulty = selected;
-
-                            state = GameState.START;
-                        }
-
-                        selected = 0;
-                        break;
-                    case KeyEvent.VK_UP:
-                        if (selected > 0) selected--;
-                        break;
-                    case KeyEvent.VK_DOWN:
-                        String[] choices = state == GameState.LEVEL_SELECT ? levels : Game.this.choices;
-                        if (selected < choices.length - 1) selected++;
-                        break;
-                }
-            }
-
-            private void pausedKeyHandler(KeyEvent e) {
-                switch (e.getKeyCode()) {
-                    case KeyEvent.VK_UP:
-                        if (selected > 0) selected--;
-                        break;
-                    case KeyEvent.VK_DOWN:
-                        if (selected < choices.length - 1) selected++;
-                        break;
-                    case KeyEvent.VK_ENTER:
-                        if (selected == 1) {
-                            playField = new PlayField(12, 12, LevelType.values()[difficulty], currentLevel);
-                        } else if (selected == 2) {
-                            state = GameState.START;
-                            selected = 0;
-                            Game.loadSound("opening.wav");
-                            return;
-                        }
-
-                        selected = 0;
-                        state = GameState.PLAYING;
-                        break;
-
+                    menus.get(state).dispatchEvent(e);
                 }
             }
         });
@@ -154,29 +63,17 @@ public class Game extends JComponent {
         addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                int x = e.getX();
-                int y = e.getY();
-
-                if (state == GameState.PAUSED) {
-                    if (x > 168 && x < 208 && y > 594 && y < 636) sound = !sound;
-                    if (x > 213 && x < 253 && y > 594 && y < 636) fx = !fx;
-                } else {
-                    if (x > 240 && x < 280 && y > 640 && y < 680) {
-                        sound = !sound;
-
-                        if (sound) {
-                            clip.start();
-                        } else {
-                            clip.stop();
-                        }
-                    }
-                    if (x > 285 && x < 325 && y > 640 && y < 680) fx = !fx;
+                if (state != GameState.PLAYING) {
+                    menus.get(state).dispatchEvent(e);
                 }
             }
         });
 
-        loadFont();
-        loadImages();
+        menus.put(GameState.START, new StartMenu(this));
+        menus.put(GameState.LEVEL_SELECT, new LevelSelectMenu(this));
+        menus.put(GameState.PAUSED, new PauseMenu(this));
+        menus.put(GameState.FINISHED, new FinishMenu(this));
+
         Game.loadSound("opening.wav");
 
         // Start game loop.
@@ -186,14 +83,6 @@ public class Game extends JComponent {
                 gameLoop();
             }
         }).start();
-    }
-
-    private void loadFont() {
-        try {
-            font = Font.createFont(Font.TRUETYPE_FONT, getClass().getResourceAsStream("/font/pokemon.ttf")).deriveFont(32f);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
     }
 
     public static void loadSound(String filename) {
@@ -208,27 +97,49 @@ public class Game extends JComponent {
         }
     }
 
-    private void loadImages() {
-        try {
-            imageBackground = ImageIO.read(getClass().getResource("/img/menuBackground.png"));
-            imageField = ImageIO.read(getClass().getResource("/img/menuField.png"));
-            imageTitle = ImageIO.read(getClass().getResource("/img/menuTitle.png"));
-            imagePaused = ImageIO.read(getClass().getResource("/img/pauseScreen.png"));
-            imageSound = ImageIO.read(getClass().getResource("/img/sound.png"));
-            imageNoSound = ImageIO.read(getClass().getResource("/img/noSound.png"));
-            imageFx = ImageIO.read(getClass().getResource("/img/fx.png"));
-            imageNoFx = ImageIO.read(getClass().getResource("/img/noFx.png"));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
     public static void setCurrentLevel(int level) {
         currentLevel = level;
     }
 
-    public static void setFinished() {
-        state = GameState.FINISHED;
+    public static void changeState(GameState state) {
+        Game.state = state;
+    }
+
+    public void toggleSound() {
+        sound = !sound;
+
+        if (sound) {
+            clip.start();
+        } else {
+            clip.stop();
+        }
+    }
+
+    public void toggleEffects() {
+        fx = !fx;
+    }
+
+    public boolean isSoundEnabled() {
+        return sound;
+    }
+
+    public boolean isEffectsEnabled() {
+        return fx;
+    }
+
+    public void setDifficulty(int difficulty) {
+        this.difficulty = difficulty;
+    }
+
+    public void start() {
+        playField = new PlayField(12, 12, LevelType.values()[difficulty], 0);
+        state = GameState.PLAYING;
+        clip.stop();
+    }
+
+    public void restart() {
+        playField = new PlayField(12, 12, LevelType.values()[difficulty], currentLevel);
+        state = GameState.PLAYING;
     }
 
     private void gameLoop() {
@@ -250,53 +161,12 @@ public class Game extends JComponent {
 
     @Override
     protected void paintComponent(Graphics g) {
-        if (state == GameState.START || state == GameState.LEVEL_SELECT) {
-            g.setColor(Color.BLACK);
-            g.setFont(font);
-            g.drawImage(imageBackground, 0, 0, null);
-
-            g.drawImage(imageField, 225, 232, 450, 464, null);
-            g.drawImage(imageTitle, getWidth() / 2 - 200, 120, null);
-
-            g.drawImage(sound ? imageSound : imageNoSound, 240, 640, null);
-            g.drawImage(fx ? imageFx : imageNoFx, 285, 640, null);
-
-            g.setColor(Color.WHITE);
-            String[] choices = state == GameState.LEVEL_SELECT ? levels : this.choices;
-            for (int i = 0; i < choices.length; i++) {
-                g.setColor(i == selected ? Color.RED : Color.WHITE);
-
-                drawCentered(g, choices[i], 420 + (i * 32));
-            }
-        } else {
+        if (state.ordinal() >= GameState.PLAYING.ordinal()) {
             playField.paintComponent(g);
-
-            if (state == GameState.PAUSED) {
-                g.drawImage(imagePaused, 0, 0, null);
-                g.setFont(font);
-                g.drawImage(sound ? imageSound : imageNoSound, 168, 594, null);
-                g.drawImage(fx ? imageFx : imageNoFx, 213, 594, null);
-
-                for (int i = 0; i < choicesMenu.length; i++) {
-                    g.setColor(i == selected ? Color.RED : Color.WHITE);
-
-                    drawCentered(g, choicesMenu[i], 420 + (i * 32));
-                }
-            }
-
-            if (state == GameState.FINISHED) {
-                for (int i = 0; i < finishMenu.length; i++) {
-                    g.setFont(font);
-                    g.setColor(i == selected ? Color.RED : Color.WHITE);
-
-                    drawCentered(g, finishMenu[i], 420 + (i * 32));
-                }
-            }
         }
-    }
 
-    private void drawCentered(Graphics g, String str, int y) {
-        int width = g.getFontMetrics().stringWidth(str);
-        g.drawString(str, getWidth() / 2 - width / 2, y);
+        if (menus.containsKey(state)) {
+            menus.get(state).paintComponent(g);
+        }
     }
 }

--- a/src/cutthetree/Game.java
+++ b/src/cutthetree/Game.java
@@ -108,7 +108,7 @@ public class Game extends JComponent {
     public void toggleSound() {
         sound = !sound;
 
-        if (sound) {
+        if (state.ordinal() < GameState.PLAYING.ordinal() && sound) {
             clip.start();
         } else {
             clip.stop();

--- a/src/cutthetree/GameFrame.java
+++ b/src/cutthetree/GameFrame.java
@@ -8,8 +8,8 @@ import java.awt.*;
  * the correct size.
  */
 public class GameFrame extends JFrame {
-    protected final static int FRAME_HEIGHT = 900;
-    protected final static int FRAME_WIDTH = 900;
+    public final static int FRAME_HEIGHT = 900;
+    public final static int FRAME_WIDTH = 900;
 
     public GameFrame() {
         getContentPane().setPreferredSize(new Dimension(FRAME_WIDTH, FRAME_HEIGHT));

--- a/src/cutthetree/Level.java
+++ b/src/cutthetree/Level.java
@@ -63,7 +63,7 @@ public class Level {
                 if (line.trim().isEmpty()) break;
 
                 for (int x = 0; x < line.length(); x++) {
-                    if (fields.size() <= x) fields.add(new ArrayList<>());
+                    if (fields.size() <= x) fields.add(new ArrayList<Field>());
 
                     char chr = line.charAt(x);
                     if (chr == 'W') {

--- a/src/cutthetree/PlayField.java
+++ b/src/cutthetree/PlayField.java
@@ -46,31 +46,29 @@ public class PlayField extends JComponent {
             public void keyPressed(KeyEvent e) {
                 player.say("");
 
-                if (!finished) {
-                    switch (e.getKeyCode()) {
-                        case KeyEvent.VK_ESCAPE:
-                            Game.changeState(GameState.PAUSED);
-                            break;
-                        case KeyEvent.VK_UP:
-                            player.changeDirection(Direction.UP);
-                            walking = true;
-                            break;
-                        case KeyEvent.VK_DOWN:
-                            player.changeDirection(Direction.DOWN);
-                            walking = true;
-                            break;
-                        case KeyEvent.VK_LEFT:
-                            player.changeDirection(Direction.LEFT);
-                            walking = true;
-                            break;
-                        case KeyEvent.VK_RIGHT:
-                            player.changeDirection(Direction.RIGHT);
-                            walking = true;
-                            break;
-                        case KeyEvent.VK_SPACE:
-                            cut();
-                            break;
-                    }
+                switch (e.getKeyCode()) {
+                    case KeyEvent.VK_ESCAPE:
+                        Game.changeState(GameState.PAUSED);
+                        break;
+                    case KeyEvent.VK_UP:
+                        player.changeDirection(Direction.UP);
+                        walking = true;
+                        break;
+                    case KeyEvent.VK_DOWN:
+                        player.changeDirection(Direction.DOWN);
+                        walking = true;
+                        break;
+                    case KeyEvent.VK_LEFT:
+                        player.changeDirection(Direction.LEFT);
+                        walking = true;
+                        break;
+                    case KeyEvent.VK_RIGHT:
+                        player.changeDirection(Direction.RIGHT);
+                        walking = true;
+                        break;
+                    case KeyEvent.VK_SPACE:
+                        cut();
+                        break;
                 }
             }
         });
@@ -146,8 +144,6 @@ public class PlayField extends JComponent {
     @Override
     protected void paintComponent(Graphics g) {
         if (walking) walk(player.getDirection());
-
-        ((Graphics2D) g).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
         for (ArrayList<Field> row : fields) {
             for (Field field : row) {

--- a/src/cutthetree/PlayField.java
+++ b/src/cutthetree/PlayField.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 public class PlayField extends JComponent {
     private static Image imageAxe;
     private static Image imageBackpack;
-    private static Image imageFinishScreen;
 
     private boolean finished = false;
 
@@ -49,6 +48,9 @@ public class PlayField extends JComponent {
 
                 if (!finished) {
                     switch (e.getKeyCode()) {
+                        case KeyEvent.VK_ESCAPE:
+                            Game.changeState(GameState.PAUSED);
+                            break;
                         case KeyEvent.VK_UP:
                             player.changeDirection(Direction.UP);
                             walking = true;
@@ -83,7 +85,6 @@ public class PlayField extends JComponent {
         try {
             imageBackpack = ImageIO.read(PlayField.class.getResource("/img/backpack-icon.png"));
             imageAxe = ImageIO.read(PlayField.class.getResource("/img/axes.png"));
-            imageFinishScreen = ImageIO.read(PlayField.class.getResource("/img/finished.png"));
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -131,7 +132,7 @@ public class PlayField extends JComponent {
 
         if (fields.get(x + dx).get(y + dy) instanceof Finish) {
             Game.loadSound("winning.wav");
-            Game.setFinished();
+            Game.changeState(GameState.FINISHED);
             finished = true;
             fields.get(x).set(y, new Field(x, y));
 
@@ -159,7 +160,6 @@ public class PlayField extends JComponent {
 
         paintBackpack(g);
         if (!finished) player.paint(g);
-        if (finished) g.drawImage(imageFinishScreen, 0, 0, null);
     }
 
     /**

--- a/src/cutthetree/menus/FinishMenu.java
+++ b/src/cutthetree/menus/FinishMenu.java
@@ -1,0 +1,39 @@
+package cutthetree.menus;
+
+import cutthetree.Game;
+import cutthetree.GameState;
+import cutthetree.PlayField;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+
+public class FinishMenu extends Menu {
+    private static Image background;
+
+    public FinishMenu(Game game) {
+        super(game, "Exit");
+
+        if (background == null) loadImage();
+    }
+
+    private static void loadImage() {
+        try {
+            background = ImageIO.read(PlayField.class.getResource("/img/finished.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    void itemSelected(int index) {
+        Game.changeState(GameState.START);
+        Game.loadSound("opening.wav");
+    }
+
+    @Override
+    public void paintComponent(Graphics g) {
+        g.drawImage(background, 0, 0, null);
+
+        paintChoices(g);
+    }
+}

--- a/src/cutthetree/menus/LevelSelectMenu.java
+++ b/src/cutthetree/menus/LevelSelectMenu.java
@@ -1,0 +1,16 @@
+package cutthetree.menus;
+
+import cutthetree.Game;
+import cutthetree.GameState;
+
+public class LevelSelectMenu extends StartMenu {
+    public LevelSelectMenu(Game game) {
+        super(game, "Tutorial", "Easy", "Medium", "Hard");
+    }
+
+    @Override
+    void itemSelected(int index) {
+        game.setDifficulty(index);
+        Game.changeState(GameState.START);
+    }
+}

--- a/src/cutthetree/menus/Menu.java
+++ b/src/cutthetree/menus/Menu.java
@@ -1,0 +1,109 @@
+package cutthetree.menus;
+
+import cutthetree.Game;
+import cutthetree.GameFrame;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+public abstract class Menu extends JComponent {
+    protected static Image imageSound, imageNoSound;
+    protected static Image imageFx, imageNoFx;
+    protected static Font font;
+
+    protected final String[] choices;
+    protected int selected = 0;
+    protected Game game;
+
+    protected Menu(Game game, String... choices) {
+        this.game = game;
+        this.choices = choices;
+
+        addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                onKeyPress(e);
+            }
+        });
+
+        if (imageSound == null || imageFx == null) loadImages();
+        if (font == null) loadFont();
+    }
+
+    private static void loadImages() {
+        try {
+            imageSound = ImageIO.read(Menu.class.getResource("/img/sound.png"));
+            imageNoSound = ImageIO.read(Menu.class.getResource("/img/noSound.png"));
+            imageFx = ImageIO.read(Menu.class.getResource("/img/fx.png"));
+            imageNoFx = ImageIO.read(Menu.class.getResource("/img/noFx.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void loadFont() {
+        try {
+            font = Font.createFont(Font.TRUETYPE_FONT, Menu.class.getResourceAsStream("/font/pokemon.ttf")).deriveFont(32f);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    protected void onKeyPress(KeyEvent e) {
+        switch (e.getKeyCode()) {
+            case KeyEvent.VK_UP:
+                if (selected > 0) selected--;
+                break;
+            case KeyEvent.VK_DOWN:
+                if (selected < choices.length - 1) selected++;
+                break;
+            case KeyEvent.VK_ENTER:
+                itemSelected(selected);
+                break;
+        }
+    }
+
+    protected void enableSoundToggler(int x, int y) {
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getX() > x && e.getX() < x + 40 && e.getY() > y && e.getY() < y + 40) {
+                    game.toggleSound();
+                } else if (e.getX() > x + 45 && e.getX() < x + 85 && e.getY() > y && e.getY() < y + 40) {
+                    game.toggleEffects();
+                }
+            }
+        });
+    }
+
+    abstract void itemSelected(int index);
+
+    @Override
+    public abstract void paintComponent(Graphics g);
+
+    protected void paintSoundToggles(Graphics g, int x, int y) {
+        g.drawImage(game.isSoundEnabled() ? imageSound : imageNoSound, x, y, null);
+        g.drawImage(game.isEffectsEnabled() ? imageFx : imageNoFx, x + 45, y, null);
+    }
+
+    protected void paintChoices(Graphics g) {
+        g.setFont(font);
+
+        for (int i = 0; i < choices.length; i++) {
+            g.setColor(i == selected ? Color.RED : Color.WHITE);
+
+            drawCentered(g, choices[i], 420 + (i * 32));
+        }
+    }
+
+    protected void drawCentered(Graphics g, String str, int y) {
+        int width = g.getFontMetrics().stringWidth(str);
+
+        g.drawString(str, GameFrame.FRAME_WIDTH / 2 - width / 2, y);
+    }
+}

--- a/src/cutthetree/menus/Menu.java
+++ b/src/cutthetree/menus/Menu.java
@@ -68,7 +68,7 @@ public abstract class Menu extends JComponent {
         }
     }
 
-    protected void enableSoundToggler(int x, int y) {
+    protected void enableSoundToggler(final int x, final int y) {
         addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {

--- a/src/cutthetree/menus/PauseMenu.java
+++ b/src/cutthetree/menus/PauseMenu.java
@@ -1,0 +1,59 @@
+package cutthetree.menus;
+
+import cutthetree.Game;
+import cutthetree.GameState;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.event.KeyEvent;
+
+public class PauseMenu extends Menu {
+    private static Image background;
+
+    public PauseMenu(Game game) {
+        super(game, "Continue", "Restart", "Exit");
+
+        enableSoundToggler(168, 594);
+        if (background == null) loadImage();
+    }
+
+    private static void loadImage() {
+        try {
+            background = ImageIO.read(PauseMenu.class.getResource("/img/pauseScreen.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    protected void onKeyPress(KeyEvent e) {
+        if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
+            Game.changeState(GameState.PLAYING);
+            selected = 0;
+        } else {
+            super.onKeyPress(e);
+        }
+    }
+
+    @Override
+    void itemSelected(int index) {
+        if (index == 0) {
+            Game.changeState(GameState.PLAYING);
+        } else if (index == 1) {
+            game.restart();
+        } else if (index == 2) {
+            Game.changeState(GameState.START);
+            Game.loadSound("opening.wav");
+        }
+
+        selected = 0;
+    }
+
+    @Override
+    public void paintComponent(Graphics g) {
+        g.drawImage(background, 0, 0, null);
+
+        paintSoundToggles(g, 168, 594);
+        paintChoices(g);
+    }
+}

--- a/src/cutthetree/menus/StartMenu.java
+++ b/src/cutthetree/menus/StartMenu.java
@@ -1,0 +1,59 @@
+package cutthetree.menus;
+
+import cutthetree.Game;
+import cutthetree.GameFrame;
+import cutthetree.GameState;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+
+public class StartMenu extends Menu {
+    private static Image background;
+    private static Image menuField;
+    private static Image title;
+
+    public StartMenu(Game game) {
+        this(game, "Start", "Difficulty", "Exit");
+    }
+
+    protected StartMenu(Game game, String... choices) {
+        super(game, choices);
+
+        enableSoundToggler(240, 640);
+        if (background == null || menuField == null || title == null) loadImage();
+    }
+
+    private static void loadImage() {
+        try {
+            background = ImageIO.read(StartMenu.class.getResource("/img/menuBackground.png"));
+            menuField = ImageIO.read(StartMenu.class.getResource("/img/menuField.png"));
+            title = ImageIO.read(StartMenu.class.getResource("/img/menuTitle.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    void itemSelected(int index) {
+        if (index == 0) {
+            game.start();
+        } else if (index == 1) {
+            Game.changeState(GameState.LEVEL_SELECT);
+        } else if (index == 2) {
+            System.exit(0);
+        }
+
+        selected = 0;
+    }
+
+    @Override
+    public void paintComponent(Graphics g) {
+        g.drawImage(background, 0, 0, null);
+
+        g.drawImage(title, GameFrame.FRAME_WIDTH / 2 - 200, 120, null);
+        g.drawImage(menuField, 225, 232, 450, 464, null);
+
+        paintSoundToggles(g, 240, 640);
+        paintChoices(g);
+    }
+}


### PR DESCRIPTION
Add specific Menu classes to handle the different types of menus

This moves the mouse and key listeners to the Menu class.

Game now keeps a Map of GameState => Menu to draw depending on the current GameState