### PR TITLE
Player direction walking

### DIFF
--- a/src/cutthetree/Direction.java
+++ b/src/cutthetree/Direction.java
@@ -1,5 +1,7 @@
 package cutthetree;
 
+import java.awt.event.KeyEvent;
+
 /**
  * This represents the current direction of a {@link Player}
  */
@@ -23,5 +25,16 @@ public enum Direction {
 
     public int getDy() {
         return dy;
+    }
+
+    public static Direction fromKeyCode(int code) {
+        switch (code) {
+            case KeyEvent.VK_DOWN: return Direction.DOWN;
+            case KeyEvent.VK_UP: return Direction.UP;
+            case KeyEvent.VK_LEFT: return Direction.LEFT;
+            case KeyEvent.VK_RIGHT: return Direction.RIGHT;
+        }
+
+        return null;
     }
 }

--- a/src/cutthetree/PlayField.java
+++ b/src/cutthetree/PlayField.java
@@ -23,9 +23,9 @@ public class PlayField extends JComponent {
     private Player player;
 
     /**
-     * If the player is currently walking or not
+     * The current direction the player is walking in
      */
-    private boolean walking = false;
+    private Direction walking = null;
     private ArrayList<ArrayList<Field>> fields = new ArrayList<>();
 
     public PlayField(LevelType type, int levelNumber) {
@@ -38,7 +38,9 @@ public class PlayField extends JComponent {
         addKeyListener(new KeyAdapter() {
             @Override
             public void keyReleased(KeyEvent e) {
-                walking = false;
+                if (walking == Direction.fromKeyCode(e.getKeyCode())) {
+                    walking = null;
+                }
             }
 
             @Override
@@ -50,20 +52,10 @@ public class PlayField extends JComponent {
                         Game.changeState(GameState.PAUSED);
                         break;
                     case KeyEvent.VK_UP:
-                        player.changeDirection(Direction.UP);
-                        walking = true;
-                        break;
                     case KeyEvent.VK_DOWN:
-                        player.changeDirection(Direction.DOWN);
-                        walking = true;
-                        break;
                     case KeyEvent.VK_LEFT:
-                        player.changeDirection(Direction.LEFT);
-                        walking = true;
-                        break;
                     case KeyEvent.VK_RIGHT:
-                        player.changeDirection(Direction.RIGHT);
-                        walking = true;
+                        walking = Direction.fromKeyCode(e.getKeyCode());
                         break;
                     case KeyEvent.VK_SPACE:
                         cut();
@@ -110,6 +102,8 @@ public class PlayField extends JComponent {
      * Let the player walk in the given direction.
      */
     private void walk(Direction direction) {
+        if (player.isMoving()) return;
+
         player.changeDirection(direction);
 
         int x = player.xPos;
@@ -142,7 +136,7 @@ public class PlayField extends JComponent {
 
     @Override
     protected void paintComponent(Graphics g) {
-        if (walking) walk(player.getDirection());
+        if (walking != null) walk(walking);
 
         for (ArrayList<Field> row : fields) {
             for (Field field : row) {

--- a/src/cutthetree/PlayField.java
+++ b/src/cutthetree/PlayField.java
@@ -47,19 +47,12 @@ public class PlayField extends JComponent {
             public void keyPressed(KeyEvent e) {
                 player.say("");
 
-                switch (e.getKeyCode()) {
-                    case KeyEvent.VK_ESCAPE:
-                        Game.changeState(GameState.PAUSED);
-                        break;
-                    case KeyEvent.VK_UP:
-                    case KeyEvent.VK_DOWN:
-                    case KeyEvent.VK_LEFT:
-                    case KeyEvent.VK_RIGHT:
-                        walking = Direction.fromKeyCode(e.getKeyCode());
-                        break;
-                    case KeyEvent.VK_SPACE:
-                        cut();
-                        break;
+                if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
+                    Game.changeState(GameState.PAUSED);
+                } else if (e.getKeyCode() == KeyEvent.VK_SPACE) {
+                    cut();
+                } else if (Direction.fromKeyCode(e.getKeyCode()) != null) {
+                    walking = Direction.fromKeyCode(e.getKeyCode());
                 }
             }
         });

--- a/src/cutthetree/Player.java
+++ b/src/cutthetree/Player.java
@@ -49,9 +49,13 @@ public class Player extends Field {
         }
     }
 
+    public boolean isMoving() {
+        return animX + animY != 0;
+    }
+
     public boolean move(int dx, int dy) {
         // Disallow move while animating
-        if (animX + animY != 0) return false;
+        if (isMoving()) return false;
 
         animX = dx;
         animY = dy;


### PR DESCRIPTION
Change player direction only after animation is done to remove moonwalk/sidewalk

This also fixes a bug when multiple keys are pressed the first one to be released the player stops walking. Now it stops walking when the last pressed key is released.